### PR TITLE
change minimum supported julia version to 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.3
+julia 0.4


### PR DESCRIPTION
due to the use of `=>`

The next tag ~~that~~ whether or not it includes this commit needs to be a new minor version via `Pkg.tag("MacroTools", :minor)` - same with Requires.jl