### PR TITLE
Fix readstring undefined error on 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat

--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -1,5 +1,7 @@
 module MacroTools
 
+using Compat
+
 export @match, @capture
 
 include("match.jl")


### PR DESCRIPTION
This breaks PyPlot on 0.4.