### PR TITLE
Fix transpose/ctranspose mapping in `resyntax`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -151,7 +151,8 @@ function resyntax(ex)
     @match x begin
       setfield!(x_, :f_, x_.f_ + v_) => :($x.$f += $v)
       setfield!(x_, :f_, v_) => :($x.$f = $v)
-      transpose(x_) => :($x')
+      ctranspose(x_) => :($x')
+      transpose(x_) => :($x.')
       _ => x
     end
   end


### PR DESCRIPTION
Previously `resyntax` was mapping `transpose(x)` to `x'`. That should instead be mapped to `x.'`; `ctranspose(x)` corresponds to `x'`. This does not affect real matrices, but makes a difference for complex matrices:

```julia
julia> ctranspose(im) == im'
true

julia> transpose(im) == im'
false

julia> transpose(im) == im.'
true
```