### PR TITLE
Fixes for 0.5

### DIFF
--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -1,3 +1,4 @@
+__precompile__(true)
 module MacroTools
 
 using Compat

--- a/src/examples/destruct.jl
+++ b/src/examples/destruct.jl
@@ -20,7 +20,7 @@ get′(xs, k, v) = get(xs, k, v)
 get′(xs, k) = getindex(xs, k)
 
 getkeym(args...) = :(MacroTools.get′($(args...)))
-getfieldm(val, i) = :($val.($i))
+getfieldm(val, i) = :(getfield($val,$i))
 getfieldm(val, i, default) = error("Can't destructure fields with default values")
 
 function destruct_key(pat, val, getm)


### PR DESCRIPTION
Hi, this PR fixes two things that were causing problems for me in 0.5.

First, it was missing `__precompile__` at the top of the module, which is problematic since it is used by other precompiled modules.

Second, it was using the deprecated `foo.(i)` syntax for `getfield`.

Can a new version be tagged after this is merged?  MacroTools is important for PyCall.