### PR TITLE
Support function return types in longdef/shortdef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
+matrix:
+    allow_failures:
+    - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/README.md
+++ b/README.md
@@ -220,14 +220,14 @@ end
 and returns a `Dict` with keys `:name`, `:args`, `:kwargs` and `:body`. If there is
 a return type in the definition, `:rtype` will be in the dictionary, too. 
 
-`splitarg(arg)` matches function arguments (whether from a definition or a function
-call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:
+`splitarg(arg)` matches function arguments (whether from a definition or a function call)
+such as `x::Int=2` and returns `(arg_name, arg_type, default)`. `default` is `nothing`
+when there is none. For example:
 
 ```julia
-> map(splitarg, splitdef(:(f(a=2, x::Int=nothing, y)=x))[:args])
+> map(splitarg, (:(f(a=2, x::Int=nothing, y))).args[2:end])
 3-element Array{Tuple{Symbol,Symbol,Any},1}:
  (:a, :Any, 2)       
  (:x, :Int, :nothing)
  (:y, :Any, nothing)
 ```
-

--- a/README.md
+++ b/README.md
@@ -220,11 +220,11 @@ end
 and returns a `Dict` with keys `:name`, `:args`, `:kwargs` and `:body`. If there is
 a return type in the definition, `:rtype` will be in the dictionary, too. 
 
-`parsearg(arg)` matches function arguments (whether from a definition or a function
+`splitarg(arg)` matches function arguments (whether from a definition or a function
 call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:
 
 ```julia
-> map(parsearg, splitdef(:(f(a=2, x::Int=nothing, y)=x))[:args])
+> map(splitarg, splitdef(:(f(a=2, x::Int=nothing, y)=x))[:args])
 3-element Array{Tuple{Symbol,Symbol,Any},1}:
  (:a, :Any, 2)       
  (:x, :Int, :nothing)

--- a/README.md
+++ b/README.md
@@ -209,15 +209,16 @@ end
 
 ## Function definitions
 
-`splitdef(fundef)` matches a function definition such as
+`splitdef(def)` matches a function definition such as
 
 ```julia
 function fname(args; kwargs)::return_type
-   body_block
+   body
 end
 ```
 
-and returns `(fname::Symbol, args::Vector{Any}, kwargs::Vector{Any}, body_block::Expr, return_type)`. `return_type` is `:Any` if not specified.
+and returns a `Dict` with keys `:name`, `:args`, `:kwargs` and `:body`. If there is
+a return type in the definition, `:rtype` will be in the dictionary, too. 
 
 `parsearg(arg)` matches a function argument (whether from a definition, or a funtion
 call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:

--- a/README.md
+++ b/README.md
@@ -220,8 +220,14 @@ end
 and returns a `Dict` with keys `:name`, `:args`, `:kwargs` and `:body`. If there is
 a return type in the definition, `:rtype` will be in the dictionary, too. 
 
-`parsearg(arg)` matches a function argument (whether from a definition, or a funtion
+`parsearg(arg)` matches function arguments (whether from a definition or a function
 call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:
 
- - `parsearg(splitdef(:(f(x::Int=2)=3))[2][1]) -> (:x, :Int, Nullable(2))`.
- - `parsearg(:x) -> (:x, :Any, Nullable())`
+```julia
+> map(parsearg, splitdef(:(f(a=2, x::Int=nothing, y)=x))[:args])
+3-element Array{Tuple{Symbol,Symbol,Any},1}:
+ (:a, :Any, 2)       
+ (:x, :Int, :nothing)
+ (:y, :Any, nothing)
+```
+

--- a/README.md
+++ b/README.md
@@ -206,3 +206,21 @@ macro foo(ex)
   end
 end
 ```
+
+## Function definitions
+
+`parsedef(fundef)` matches a function definition such as
+
+```julia
+function fname(args; kwargs)::return_type
+   body_block
+end
+```
+
+and returns `(fname::Symbol, args::Vector{Any}, kwargs::Vector{Any}, body_block::Expr, return_type)`. `return_type` is `:Any` if not specified.
+
+`parsearg(arg)` matches a function argument (whether from a definition, or a funtion
+call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:
+
+ - `parsearg(parsedef(:(f(x::Int=2)=3))[2][1]) -> (:x, :Int, Nullable(2))`.
+ - `parsearg(:x) -> (:x, :Any, Nullable())`

--- a/README.md
+++ b/README.md
@@ -209,16 +209,24 @@ end
 
 ## Function definitions
 
-`splitdef(def)` matches a function definition such as
+`splitdef(def)` matches a function definition of the form
 
 ```julia
-function fname(args; kwargs)::return_type
+function name{params}(args; kwargs)::rtype where {whereparams}
    body
 end
-```
 
-and returns a `Dict` with keys `:name`, `:args`, `:kwargs` and `:body`. If there is
-a return type in the definition, `:rtype` will be in the dictionary, too. 
+and returns `Dict(:name=>..., :args=>..., etc.)`. The definition can be rebuilt by
+calling `MacroTools.combinedef(dict)`, or explicitly with
+
+```julia
+rtype = get(dict, :rtype, :Any)
+all_params = [get(dict, :params, [])..., get(dict, :whereparams, [])...]
+:(function $(dict[:name]){$(all_params...)}($(dict[:args]...);
+                                            $(dict[:kwargs]...))::$rtype
+      $(dict[:body])
+  end)
+```
 
 `splitarg(arg)` matches function arguments (whether from a definition or a function call)
 such as `x::Int=2` and returns `(arg_name, arg_type, default)`. `default` is `nothing`

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ end
 
 ## Function definitions
 
-`parsedef(fundef)` matches a function definition such as
+`splitdef(fundef)` matches a function definition such as
 
 ```julia
 function fname(args; kwargs)::return_type
@@ -222,5 +222,5 @@ and returns `(fname::Symbol, args::Vector{Any}, kwargs::Vector{Any}, body_block:
 `parsearg(arg)` matches a function argument (whether from a definition, or a funtion
 call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:
 
- - `parsearg(parsedef(:(f(x::Int=2)=3))[2][1]) -> (:x, :Int, Nullable(2))`.
+ - `parsearg(splitdef(:(f(x::Int=2)=3))[2][1]) -> (:x, :Int, Nullable(2))`.
  - `parsearg(:x) -> (:x, :Any, Nullable())`

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 Compat 0.26.0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -158,6 +158,7 @@ function longdef(ex)
   prewalk(ex) do ex
     @match ex begin
       (f_(args__) = body_) => @q function $f($(args...)) $body end
+      (f_(args__)::rtype_ = body_) => @q function $f($(args...))::$rtype $body end
       ((args__,) -> body_) => @q function ($(args...),) $body end
       (arg_ -> body_) => @q function ($arg,) $body end
       _ => ex
@@ -169,6 +170,7 @@ function shortdef(ex)
   prewalk(ex) do ex
     @match ex begin
       function f_(args__) body_ end => @q $f($(args...)) = $body
+      function f_(args__)::rtype_ body_ end => @q $f($(args...))::$rtype = $body
       function (args__,) body_ end => @q ($(args...),) -> $body
       ((args__,) -> body_) => ex
       (arg_ -> body_) => @q ($arg,) -> $body

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -225,7 +225,7 @@ call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. `default` 
 ```
 """
 function splitarg(arg_expr)
-    split_var(arg_expr) = (@capture(arg, name_::T_)) ? (name, T) : (arg_expr, :Any)
+    split_var(arg) = (@capture(arg, name_::T_)) ? (name, T) : (arg, :Any)
     if @capture(arg_expr, arg_ = default_)
         @assert default !== nothing "splitarg cannot handle `nothing` as a default. Use a quoted `nothing` if possible. (MacroTools#35)"
         return (split_var(arg)..., default)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -154,30 +154,28 @@ isdef(ex) = ismatch(or_(:(function _(__) _ end),
                         :(f_(__) = _)),
                     ex)
 
-function longdef(ex)
-  prewalk(ex) do ex
-    @match ex begin
-      (f_(args__) = body_) => @q function $f($(args...)) $body end
-      (f_(args__)::rtype_ = body_) => @q function $f($(args...))::$rtype $body end
-      ((args__,) -> body_) => @q function ($(args...),) $body end
-      (arg_ -> body_) => @q function ($arg,) $body end
-      _ => ex
-    end
+function longdef1(ex)
+  @match ex begin
+    (f_(args__) = body_) => @q function $f($(args...)) $body end
+    (f_(args__)::rtype_ = body_) => @q function $f($(args...))::$rtype $body end
+    ((args__,) -> body_) => @q function ($(args...),) $body end
+    (arg_ -> body_) => @q function ($arg,) $body end
+    _ => ex
   end
 end
+longdef(ex) = prewalk(longdef1, ex)
 
-function shortdef(ex)
-  prewalk(ex) do ex
-    @match ex begin
-      function f_(args__) body_ end => @q $f($(args...)) = $body
-      function f_(args__)::rtype_ body_ end => @q $f($(args...))::$rtype = $body
-      function (args__,) body_ end => @q ($(args...),) -> $body
-      ((args__,) -> body_) => ex
-      (arg_ -> body_) => @q ($arg,) -> $body
-      _ => ex
-    end
+function shortdef1(ex)
+  @match ex begin
+    function f_(args__) body_ end => @q $f($(args...)) = $body
+    function f_(args__)::rtype_ body_ end => @q $f($(args...))::$rtype = $body
+    function (args__,) body_ end => @q ($(args...),) -> $body
+    ((args__,) -> body_) => ex
+    (arg_ -> body_) => @q ($arg,) -> $body
+    _ => ex
   end
 end
+shortdef(ex) = prewalk(shortdef1, ex)
 
 function flatten1(ex)
   isexpr(ex, :block) || return ex

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 export @esc, isexpr, isline, rmlines, unblock, block, inexpr, namify, isdef,
-  longdef, shortdef, @expand, makeif, prettify, splitdef, parsearg
+  longdef, shortdef, @expand, makeif, prettify, splitdef, splitarg
 
 assoc!(d, k, v) = (d[k] = v; d)
 
@@ -212,22 +212,22 @@ function splitdef(fdef)
 end
 
 
-""" `parsearg(arg)` matches function arguments (whether from a definition or a function
+""" `splitarg(arg)` matches function arguments (whether from a definition or a function
 call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:
 
 ```julia
-> map(parsearg, splitdef(:(f(a=2, x::Int=nothing, y)=x))[:args])
+> map(splitarg, splitdef(:(f(a=2, x::Int=nothing, y)=x))[:args])
 3-element Array{Tuple{Symbol,Symbol,Any},1}:
  (:a, :Any, 2)       
  (:x, :Int, :nothing)
  (:y, :Any, nothing)
 ```
 """
-function parsearg(arg_expr)
+function splitarg(arg_expr)
     if isa(arg_expr, Expr) && arg_expr.head == :kw
         default = arg_expr.args[2]
         arg_expr = arg_expr.args[1]
-        @assert default !== nothing "parsearg cannot handle `nothing` as a default. Use a quoted `nothing` if possible. (MacroTools#35)"
+        @assert default !== nothing "splitarg cannot handle `nothing` as a default. Use a quoted `nothing` if possible. (MacroTools#35)"
     else
         default = nothing
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -202,13 +202,17 @@ a return type in the definition, `:rtype` will be in the dictionary, too. """
 function splitdef(fdef)
     mkdict(fname, args, kwargs, body, other_pairs...) =
         Dict(:name=>fname, :args=>args, :kwargs=>kwargs, :body=>body, other_pairs...)
-    @match longdef1(fdef) begin
-        (function fname_(args__) body_ end =>
-         mkdict(fname, splitkwargs(args)..., body))
-        (function fname_(args__)::rtype_ body_ end =>
-         mkdict(fname, splitkwargs(args)..., body, :rtype=>rtype))
-        any_ => error("Not a function definition: $fdef")
+    error_msg = "Not a function definition: $fdef"
+    @assert(@capture(longdef1(fdef),
+                     function ((fname_(allargs__)) | (fname_(allargs__)::rtype_))
+                     body_ end),
+            error_msg)
+    args, kwargs = splitkwargs(allargs)
+    di = Dict(:name=>fname, :args=>args, :kwargs=>kwargs, :body=>body)
+    if rtype != nothing
+        di[:rtype] = rtype
     end
+    di
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -252,7 +252,7 @@ end
 `combinearg` is the inverse of `splitarg`. """
 function combinearg(arg_name, arg_type, is_splat, default)
     a = arg_name===nothing ? :(::$arg_type) : :($arg_name::$arg_type)
-    a2 = is_splat ? :($a...) : a
+    a2 = is_splat ? Expr(:..., a) : a
     return default === nothing ? a2 : Expr(:kw, a2, default)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -246,6 +246,16 @@ function combinedef(dict::Dict)
       end)
 end
 
+"""
+    combinearg(arg_name, arg_type, is_splat, default)
+
+`combinearg` is the inverse of `splitarg`. """
+function combinearg(arg_name, arg_type, is_splat, default)
+    a = arg_name===nothing ? :(::$arg_type) : :($arg_name::$arg_type)
+    a2 = is_splat ? :($a...) : a
+    return default === nothing ? a2 : Expr(:kw, a2, default)
+end
+
 
 macro splitcombine(fundef)
     dict = splitdef(fundef)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -180,17 +180,11 @@ shortdef(ex) = prewalk(shortdef1, ex)
 """ `split_kwargs(x)` splits an argument list into positional and keyword args.
 Returns `(args::Vector, kwargs::Vector)` """
 function split_kwargs(args)
-    positional_args = []
-    kwargs = []
-    for x in args
-        if isa(x, Expr) && x.head == :parameters
-            @assert kwargs == []
-            kwargs = x.args
-        else
-            push!(positional_args, x)
-        end
-    end
-    return (positional_args, kwargs)
+    if !isempty(args) && isa(args[1], Expr) && args[1].head == :parameters
+        return args[2:end], args[1].args
+    else
+        return args, []
+    end    
 end
 
 """    parsedef(fdef)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -177,9 +177,9 @@ function shortdef1(ex)
 end
 shortdef(ex) = prewalk(shortdef1, ex)
 
-""" `split_kwargs(x)` splits an argument list into positional and keyword args.
+""" `splitkwargs(x)` splits an argument list into positional and keyword args.
 Returns `(args::Vector, kwargs::Vector)` """
-function split_kwargs(args)
+function splitkwargs(args)
     if !isempty(args) && isa(args[1], Expr) && args[1].head == :parameters
         return args[2:end], args[1].args
     else
@@ -204,9 +204,9 @@ function splitdef(fdef)
         Dict(:name=>fname, :args=>args, :kwargs=>kwargs, :body=>body, other_pairs...)
     @match longdef1(fdef) begin
         (function fname_(args__) body_ end =>
-         mkdict(fname, split_kwargs(args)..., body))
+         mkdict(fname, splitkwargs(args)..., body))
         (function fname_(args__)::rtype_ body_ end =>
-         mkdict(fname, split_kwargs(args)..., body, :rtype=>rtype))
+         mkdict(fname, splitkwargs(args)..., body, :rtype=>rtype))
         any_ => error("Not a function definition: $fdef")
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -193,17 +193,20 @@ Match a function definition such as
 
 ```julia
 function fname(args; kwargs)::return_type
-   body_block
+   body
 end
 ```
 
-and returns `(fname::Symbol, args::Vector{Any}, kwargs::Vector{Any}, body_block::Expr, return_type)`. `return_type` is `:Any` if not specified. """
+and returns a `Dict` with keys `:name`, `:args`, `:kwargs` and `:body`. If there is
+a return type in the definition, `:rtype` will be in the dictionary, too. """
 function splitdef(fdef)
+    mkdict(fname, args, kwargs, body, other_pairs...) =
+        Dict(:name=>fname, :args=>args, :kwargs=>kwargs, :body=>body, other_pairs...)
     @match longdef1(fdef) begin
         (function fname_(args__) body_ end =>
-         (fname, split_kwargs(args)..., body, :Any))
+         mkdict(fname, split_kwargs(args)..., body))
         (function fname_(args__)::rtype_ body_ end =>
-         (fname, split_kwargs(args)..., body, rtype))
+         mkdict(fname, split_kwargs(args)..., body, :rtype=>rtype))
         any_ => error("Not a function definition: $fdef")
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -225,7 +225,12 @@ call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. `default` 
 ```
 """
 function splitarg(arg_expr)
-    split_var(arg) = (@capture(arg, name_::T_)) ? (name, T) : (arg, :Any)
+    split_var(arg) =
+        @match arg begin
+            ::T_ => (nothing, T)
+            name_::T_ => (name, T)
+            x_ => (arg, :Any)
+        end
     if @capture(arg_expr, arg_ = default_)
         @assert default !== nothing "splitarg cannot handle `nothing` as a default. Use a quoted `nothing` if possible. (MacroTools#35)"
         return (split_var(arg)..., default)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 export @esc, isexpr, isline, rmlines, unblock, block, inexpr, namify, isdef,
-  longdef, shortdef, @expand, makeif, prettify, parsedef, parsearg
+  longdef, shortdef, @expand, makeif, prettify, splitdef, parsearg
 
 assoc!(d, k, v) = (d[k] = v; d)
 
@@ -187,7 +187,7 @@ function split_kwargs(args)
     end    
 end
 
-"""    parsedef(fdef)
+"""    splitdef(fdef)
 
 Match a function definition such as
 
@@ -198,7 +198,7 @@ end
 ```
 
 and returns `(fname::Symbol, args::Vector{Any}, kwargs::Vector{Any}, body_block::Expr, return_type)`. `return_type` is `:Any` if not specified. """
-function parsedef(fdef)
+function splitdef(fdef)
     @match longdef1(fdef) begin
         (function fname_(args__) body_ end =>
          (fname, split_kwargs(args)..., body, :Any))
@@ -211,7 +211,7 @@ end
 
 """ `parsearg(arg)` matches function arguments (whether from a definition or a function
 call) such as `x::Int=2` and returns `(arg_name, arg_type, default)`. For example:
- - `parsearg(parsedef(:(f(x::Int=2)=3))[2][1]) -> (:x, :Int, Nullable(2))`.
+ - `parsearg(splitdef(:(f(x::Int=2)=3))[2][1]) -> (:x, :Int, Nullable(2))`.
  - `parsearg(:x) -> (:x, :Any, Nullable())`
 """
 function parsearg(arg_expr)

--- a/src/utilsv6.jl
+++ b/src/utilsv6.jl
@@ -1,0 +1,20 @@
+# Code that doesn't parse under Julia 0.5
+
+function longdef1_where(ex)
+    @match ex begin
+        (f_(args__) where {whereparams__} = body_) =>
+            @q function $f($(args...)) where {$(whereparams...)}
+                $body end
+        ((f_(args__)::rtype_) where {whereparams__} = body_) =>
+            @q function ($f($(args...))::$rtype) where {$(whereparams...)}
+                $body end
+        _ => ex
+    end
+end
+function splitwhere(fdef)
+    @assert(@capture(longdef1(fdef),
+                     function ((fcall_ where {whereparams__}) | fcall_)
+                     body_ end),
+            "Not a function definition: $fdef")
+    return fcall, body, whereparams
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,9 +96,8 @@ let
         Dict(:name=>:foo, :args=>[:a, Expr(:kw, :(b::Int), 2)],
              :kwargs=>[Expr(:kw, :c, 3)],
              :body=>MacroTools.striplines(quote a+b end), :rtype=>:Int)
-    # == isn't defined on Nullables
-    @test map(arg->parsearg(arg)[1:2], def_elts[:args]) == [(:a, :Any), (:b, :Int)]
-    @test isnull(parsearg(def_elts[:args][1])[3])
+    @test map(arg->parsearg(arg), def_elts[:args]) == [(:a, :Any, nothing), (:b, :Int, 2)]
+    @test parsearg(def_elts[:args][1])[3] === nothing
 end
 
 include("destruct.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,7 +91,7 @@ let
     # but it fails because of :line and :block differences
     @test longdef(:(f(x)::Int = 10)).head == :function
     @test shortdef(:(function f(x)::Int 10 end)).head != :function
-    name, args, kwargs, body, rtype = parsedef(:(foo(a, b::Int=2; c=3)::Int = a+b))
+    name, args, kwargs, body, rtype = splitdef(:(foo(a, b::Int=2; c=3)::Int = a+b))
     @test (name, args, kwargs, body, rtype) ==
         (:foo, [:a, Expr(:kw, :(b::Int), 2)], [Expr(:kw, :c, 3)],
          MacroTools.striplines(quote a+b end), :Int)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,9 @@ let
     @test add(1; d=10) === 16.0
     @splitcombine fparam{T}(a::T) = T
     @test fparam([]) == Vector{Any}
+    immutable Orange end
+    @splitcombine (::Orange)(x) = x+2
+    @test Orange()(10) == 12
     if VERSION >= v"0.6.0"
         include_string("""
         @splitcombine fwhere(a::T) where T = T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,11 +91,11 @@ let
     # but it fails because of :line and :block differences
     @test longdef(:(f(x)::Int = 10)).head == :function
     @test shortdef(:(function f(x)::Int 10 end)).head != :function
-    def_elts = splitdef(:(foo(a, b::Int=2; c=3)::Int = a+b))
+    def_elts = splitdef(MacroTools.striplines(:(foo(a, b::Int=2; c=3)::Int = a+b)))
     @test def_elts ==
         Dict(:name=>:foo, :args=>[:a, Expr(:kw, :(b::Int), 2)],
              :kwargs=>[Expr(:kw, :c, 3)],
-             :body=>MacroTools.striplines(quote a+b end), :rtype=>:Int)
+             :body=>MacroTools.striplines(quote begin a+b end end), :rtype=>:Int)
     @test map(splitarg, def_elts[:args]) == [(:a, :Any, nothing), (:b, :Int, 2)]
     @test splitarg(def_elts[:args][1])[3] === nothing
     @test map(splitarg, (:(f(a=2, x::Int=nothing, y))).args[2:end]) ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,8 +96,10 @@ let
         Dict(:name=>:foo, :args=>[:a, Expr(:kw, :(b::Int), 2)],
              :kwargs=>[Expr(:kw, :c, 3)],
              :body=>MacroTools.striplines(quote a+b end), :rtype=>:Int)
-    @test map(arg->splitarg(arg), def_elts[:args]) == [(:a, :Any, nothing), (:b, :Int, 2)]
+    @test map(splitarg, def_elts[:args]) == [(:a, :Any, nothing), (:b, :Int, 2)]
     @test splitarg(def_elts[:args][1])[3] === nothing
+    @test map(splitarg, (:(f(a=2, x::Int=nothing, y))).args[2:end]) ==
+        [(:a, :Any, 2), (:x, :Int, :nothing), (:y, :Any, nothing)]
 end
 
 include("destruct.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,4 +86,11 @@ macro nothing_macro()
 end
 @test @expand(@nothing_macro) === nothing
 
+let
+    # Ideally we'd compare the result against :(function f(x)::Int 10 end),
+    # but it fails because of :line and :block differences
+    @test longdef(:(f(x)::Int = 10)).head == :function
+    @test shortdef(:(function f(x)::Int 10 end)).head != :function
+end
+
 include("destruct.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,9 +96,10 @@ let
     # but it fails because of :line and :block differences
     @test longdef(:(f(x)::Int = 10)).head == :function
     @test shortdef(:(function f(x)::Int 10 end)).head != :function
-    @test map(splitarg, (:(f(a=2, x::Int=nothing, y))).args[2:end]) ==
-        [(:a, :Any, 2), (:x, :Int, :nothing), (:y, :Any, nothing)]
-    @test splitarg(:(::Int)) == (nothing, :Int, nothing)
+    @test map(splitarg, (:(f(a=2, x::Int=nothing, y, args...))).args[2:end]) ==
+        [(:a, :Any, false, 2), (:x, :Int, false, :nothing),
+         (:y, :Any, false, nothing), (:args, :Any, true, nothing)]
+    @test splitarg(:(::Int)) == (nothing, :Int, false, nothing)
 
     @splitcombine foo(x) = x+2
     @test foo(10) == 12

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,8 +96,8 @@ let
         Dict(:name=>:foo, :args=>[:a, Expr(:kw, :(b::Int), 2)],
              :kwargs=>[Expr(:kw, :c, 3)],
              :body=>MacroTools.striplines(quote a+b end), :rtype=>:Int)
-    @test map(arg->parsearg(arg), def_elts[:args]) == [(:a, :Any, nothing), (:b, :Int, 2)]
-    @test parsearg(def_elts[:args][1])[3] === nothing
+    @test map(arg->splitarg(arg), def_elts[:args]) == [(:a, :Any, nothing), (:b, :Int, 2)]
+    @test splitarg(def_elts[:args][1])[3] === nothing
 end
 
 include("destruct.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,13 +91,14 @@ let
     # but it fails because of :line and :block differences
     @test longdef(:(f(x)::Int = 10)).head == :function
     @test shortdef(:(function f(x)::Int 10 end)).head != :function
-    name, args, kwargs, body, rtype = splitdef(:(foo(a, b::Int=2; c=3)::Int = a+b))
-    @test (name, args, kwargs, body, rtype) ==
-        (:foo, [:a, Expr(:kw, :(b::Int), 2)], [Expr(:kw, :c, 3)],
-         MacroTools.striplines(quote a+b end), :Int)
+    def_elts = splitdef(:(foo(a, b::Int=2; c=3)::Int = a+b))
+    @test def_elts ==
+        Dict(:name=>:foo, :args=>[:a, Expr(:kw, :(b::Int), 2)],
+             :kwargs=>[Expr(:kw, :c, 3)],
+             :body=>MacroTools.striplines(quote a+b end), :rtype=>:Int)
     # == isn't defined on Nullables
-    @test map(arg->parsearg(arg)[1:2], args) == [(:a, :Any), (:b, :Int)]
-    @test isnull(parsearg(args[1])[3])
+    @test map(arg->parsearg(arg)[1:2], def_elts[:args]) == [(:a, :Any), (:b, :Int)]
+    @test isnull(parsearg(def_elts[:args][1])[3])
 end
 
 include("destruct.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,13 @@ let
     # but it fails because of :line and :block differences
     @test longdef(:(f(x)::Int = 10)).head == :function
     @test shortdef(:(function f(x)::Int 10 end)).head != :function
+    name, args, kwargs, body, rtype = parsedef(:(foo(a, b::Int=2; c=3)::Int = a+b))
+    @test (name, args, kwargs, body, rtype) ==
+        (:foo, [:a, Expr(:kw, :(b::Int), 2)], [Expr(:kw, :c, 3)],
+         MacroTools.striplines(quote a+b end), :Int)
+    # == isn't defined on Nullables
+    @test map(arg->parsearg(arg)[1:2], args) == [(:a, :Any), (:b, :Int)]
+    @test isnull(parsearg(args[1])[3])
 end
 
 include("destruct.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,6 +100,7 @@ let
     @test splitarg(def_elts[:args][1])[3] === nothing
     @test map(splitarg, (:(f(a=2, x::Int=nothing, y))).args[2:end]) ==
         [(:a, :Any, 2), (:x, :Int, :nothing), (:y, :Any, nothing)]
+    @test splitarg(:(::Int)) == (nothing, :Int, nothing)
 end
 
 include("destruct.jl")


### PR DESCRIPTION
I also have a function that uses MacroTools to parse any function definition and return `(name, arg, kwargs, body, return_type)`. Would that be accepted?