### PR TITLE
Support typed parameters inside unions

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -19,11 +19,14 @@ function bindinglet(bs, body)
   return ex
 end
 
+ensurequoted(x) = x
+ensurequoted(x::Union{Expr, Symbol}) = Expr(:quote, x)
+
 function makeclause(pat, yes, els = nothing)
   bs = allbindings(pat)
-  pat = subtb(subor(pat))
+  pat = ensurequoted(subtb(subor(pat)))
   quote
-    env = trymatch($(Expr(:quote, pat)), ex)
+    env = trymatch($(pat), ex)
     if env != nothing
       $(bindinglet(bs, esc(yes)))
     else

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,14 +9,14 @@ istb(s::Symbol) = !(endswith(string(s), "_") || endswith(string(s), "_str")) && 
 tbname(s::Symbol) = Symbol(split(string(s), "_")[1])
 tbname(s::TypeBind) = s.name
 
-totype(s::Symbol) = string(s)[1] in 'A':'Z' ? s : Expr(:quote, s)
+totype(s::Symbol) = string(s)[1] in 'A':'Z' ? eval(s) : s
 
 function tbnew(s::Symbol)
   istb(s) || return s
   ts = map(Symbol, split(string(s), "_"))
   name = shift!(ts)
   ts = map(totype, ts)
-  Expr(:$, :(MacroTools.TypeBind($(Expr(:quote, name)), Set{Any}([$(ts...)]))))
+  MacroTools.TypeBind(name, Set{Any}([ts...]))
 end
 
 match_inner(b::TypeBind, ex, env) =

--- a/src/union.jl
+++ b/src/union.jl
@@ -22,3 +22,4 @@ subor(s) = s
 subor(s::Symbol) = s
 subor(s::Expr) = isor(s) ? subor(ornew(s)) : Expr(s.head, map(subor, s.args)...)
 subor(s::OrBind) = OrBind(subor(s.pat1), subor(s.pat2))
+subtb(s::OrBind) = OrBind(subtb(s.pat1), subtb(s.pat2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,4 +82,48 @@ let
   @test isexpr(x, :kw)
 end
 
+let
+  ex = :(x[1])
+  @test @match(ex, begin
+    v_ref => v
+  end) == ex
+
+  @test @match(ex, begin
+    v_call => v
+  end) === nothing
+
+  @test @match(:(x(1)), begin
+    v_call => v
+  end) == :(x(1))
+
+  @test @match(:(x(1)), begin
+    v_ref => v
+  end) === nothing
+
+  @test @match(ex, begin
+    (v_ref | 
+     (v_ref <= ub_)) => (v, ub)
+  end) == (ex, nothing)
+
+  @test @match(:(x <= 2), begin
+    (v_ref | 
+     (v_ref <= ub_)) => (v, ub)
+  end) == nothing
+
+  @test @match(:(x(3) <= 2), begin
+    (v_call | 
+     (v_ref <= ub_)) => (v, ub)
+  end) == (:(x(3) <= 2), nothing)  # only the first pattern matches
+
+  @test @match(:(x(3) <= 2), begin
+    ((v_ref <= ub_) |
+     v_call ) => (v, ub)
+  end) == (:(x(3) <= 2), nothing)
+
+  @test @match(:(x[1] <= 2), begin
+    (v_ref | 
+     (v_ref <= ub_)) => (v, ub)
+  end) == (:(x[1]), :(2))
+end
+
 include("destruct.jl")


### PR DESCRIPTION
Note: this is my first time working with the internals of MacroTools. I may have done something wrong. I'd appreciate as much review attention as you can spare. 

This supports typed parameters inside unions for the `@match` macro (fixes #36 ) by cleaning up some of the quoting procedures inside `types.jl`. The one sketchy part is that I call `eval()` in `types.jl` to convert `:Symbol` into the type `Symbol`. That feels wrong to me, and it may be possible to avoid it. 

The `ensurequoted` method in `macro.jl` exists so that `subtb` can return a `TypeBind` directly instead of an expression that somehow interpolates to a `TypeBind`, while still working with plain Expr and Symbol inputs. 