### PR TITLE
Initialize captured variables to nothing only if they are not defined previously

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -60,7 +60,7 @@ macro capture(ex, pat)
   bs = allbindings(pat)
   pat = subtb(subor(pat))
   quote
-    $([:($(esc(b)) = nothing) for b in bs]...)
+    $([:($(esc(Expr(:call, :isdefined, QuoteNode(b)))) || ($(esc(b)) = nothing)) for b in bs]...)
     env = trymatch($(Expr(:quote, pat)), $(esc(ex)))
     if env == nothing
       false


### PR DESCRIPTION
Right now all variables captured by @capture are initialized to `nothing`. While this is fine in most cases it is undesirable in cases where the captured variable is already defined and set to something different then nothing. This pull request therefore modifies the behaviour of @capture, such that all captured variables are only initialized to nothing in case they are not defined yet.