### PR TITLE
Rely on Compat version of `macroexpand`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7.9
+Compat 0.26

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -78,16 +78,6 @@ expressions like `foo{T}` or `Bar{T} <: Vector{T}`.
 namify(s::Symbol) = s
 namify(ex::Expr) = namify(ex.args[1])
 
-"""
-    macroexpand(::Module, expr)
-
-In its uniquely cheeky and loveable fashion, MacroTools extends this function
-to work in any module. May be useful for checking that `esc`s are done
-correctly.
-"""
-Base.macroexpand(m::Module, ex) =
-  eval(m, :(macroexpand($(Expr(:quote, ex)))))
-
 walk(x, inner, outer) = outer(x)
 walk(x::Expr, inner, outer) = outer(Expr(x.head, map(inner, x.args)...))
 


### PR DESCRIPTION
Avoids an "overwritten" warning.