### PR TITLE
fix depwarns under 0.7 and bump REQUIRE and CI to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/src/match.jl
+++ b/src/match.jl
@@ -1,4 +1,4 @@
-type MatchError
+mutable struct MatchError
   pat
   ex
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,4 @@
-immutable TypeBind
+struct TypeBind
   name::Symbol
   ts::Set{Any}
 end


### PR DESCRIPTION
(Left the `readstring` depwarn in place given the associated Compat.jl pull request hasn't merged yet.) Best! :)