### PR TITLE
Splitdef for nested where

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -184,6 +184,17 @@ function shortdef1(ex)
 end
 shortdef(ex) = prewalk(shortdef1, ex)
 
+""" `gather_wheres(:(f(x::T, y::U) where T where U)) => (:(f(x::T, y::U)), (:U, :T))`
+"""
+function gather_wheres(ex)
+  if @capture(ex, (f_ where {params1__}))
+    f2, params2 = gather_wheres(f)
+    (f2, (params1..., params2...))
+  else
+    (ex, ())
+  end
+end
+
 doc"""    splitdef(fdef)
 
 Match any function definition
@@ -207,23 +218,23 @@ all_params = [get(dict, :params, [])..., get(dict, :whereparams, [])...]
 ```
 """
 function splitdef(fdef)
-    error_msg = "Not a function definition: $fdef"
-    @assert(@capture(longdef1(fdef),
-                     function ((fcall_ where {whereparams__}) | fcall_)
-                     body_ end),
-            error_msg)
-    @assert(@capture(fcall, ((func_(args__; kwargs__)) |
-                             (func_(args__; kwargs__)::rtype_) |
-                             (func_(args__)) |
-                             (func_(args__)::rtype_))),
-            error_msg)
-    @assert(@capture(func, (fname_{params__} | fname_)), error_msg)
-    di = Dict(:name=>fname, :args=>args,
-              :kwargs=>(kwargs===nothing ? [] : kwargs), :body=>body)
-    if rtype !== nothing; di[:rtype] = rtype end
-    if whereparams !== nothing; di[:whereparams] = whereparams end
-    if params !== nothing; di[:params] = params end
-    di
+  error_msg = "Not a function definition: $fdef"
+  @assert(@capture(longdef1(fdef),
+                   function (fcall_ | fcall_) body_ end),
+          "Not a function definition: $fdef")
+  fcall_nowhere, whereparams = gather_wheres(fcall)
+  @assert(@capture(fcall_nowhere, ((func_(args__; kwargs__)) |
+                                   (func_(args__; kwargs__)::rtype_) |
+                                   (func_(args__)) |
+                                   (func_(args__)::rtype_))),
+          error_msg)
+  @assert(@capture(func, (fname_{params__} | fname_)), error_msg)
+  di = Dict(:name=>fname, :args=>args,
+            :kwargs=>(kwargs===nothing ? [] : kwargs), :body=>body)
+  if rtype !== nothing; di[:rtype] = rtype end
+  if whereparams !== nothing; di[:whereparams] = whereparams end
+  if params !== nothing; di[:params] = params end
+  di
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,11 +108,21 @@ let
     @test add(1; d=10) === 16.0
     @splitcombine fparam{T}(a::T) = T
     @test fparam([]) == Vector{Any}
-    immutable Orange end
+    struct Orange end
     @splitcombine (::Orange)(x) = x+2
     @test Orange()(10) == 12
     @splitcombine fwhere(a::T) where T = T
     @test fwhere(10) == Int
+    @splitcombine manywhere(x::T, y::Vector{U}) where T <: U where U = (T, U)
+    @test manywhere(1, Number[2.0]) == (Int, Number)
+
+    struct Foo{A, B}
+        a::A
+        b::B
+    end
+    # Parametric outer constructor
+    @splitcombine Foo{A}(a::A) where A = Foo{A, A}(a,a)
+    @test Foo{Int}(2) == Foo{Int, Int}(2, 2)
 end
 
 include("destruct.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,7 @@ let
     # Ideally we'd compare the result against :(function f(x)::Int 10 end),
     # but it fails because of :line and :block differences
     @test longdef(:(f(x)::Int = 10)).head == :function
+    @test longdef(:(f(x::T) where U where T = 2)).head == :function
     @test shortdef(:(function f(x)::Int 10 end)).head != :function
     @test map(splitarg, (:(f(a=2, x::Int=nothing, y, args...))).args[2:end]) ==
         [(:a, :Any, false, 2), (:x, :Int, false, :nothing),


### PR DESCRIPTION
This PR handles these two cases:

```julia
f(x::T, y::U) where T where U = ...
SomeType{T}(x::T) where T = ...
```

Sorry - I wish it was shorter, but I couldn't find a better way of handling nested `where`.