### PR TITLE
Fix #55, change to let expr syntax in julia v0.7

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -10,11 +10,18 @@ allbindings(pat, bs) =
 allbindings(pat) = (bs = Any[]; allbindings(pat, bs); bs)
 
 function bindinglet(bs, body)
-  ex = :(let $(esc(:env)) = env
+  # The extra unassigned gensym entices the parser to make ex.args[1] an
+  # Expr(:block,...) from the outset in v0.7.
+  ex = :(let $(gensym()), $(esc(:env)) = env
            $body
          end)
   for b in bs
-    push!(ex.args, :($(esc(b)) = get(env, $(Expr(:quote, b)), nothing)))
+    asgn = :($(esc(b)) = get(env, $(Expr(:quote, b)), nothing))
+    @static if VERSION ≥ v"0.7.0-DEV.1671"
+      push!(ex.args[1].args, asgn)
+    else
+      push!(ex.args, asgn)
+    end
   end
   return ex
 end

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -10,19 +10,10 @@ allbindings(pat, bs) =
 allbindings(pat) = (bs = Any[]; allbindings(pat, bs); bs)
 
 function bindinglet(bs, body)
-  # The extra unassigned gensym entices the parser to make ex.args[1] an
-  # Expr(:block,...) from the outset in v0.7.
-  ex = :(let $(gensym()), $(esc(:env)) = env
+  asgn = Expr[:($(esc(b)) = get(env, $(Expr(:quote, b)), nothing)) for b in bs]
+  ex = :(let $(esc(:env)) = env, $(asgn...)
            $body
          end)
-  for b in bs
-    asgn = :($(esc(b)) = get(env, $(Expr(:quote, b)), nothing))
-    @static if VERSION ≥ v"0.7.0-DEV.1671"
-      push!(ex.args[1].args, asgn)
-    else
-      push!(ex.args, asgn)
-    end
-  end
   return ex
 end
 


### PR DESCRIPTION
This fixes #55 and makes the package tests complete again on julia master.

Also appears to fix #54.

```julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.7.0-DEV.1725 (2017-09-08 14:58 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 943c8e5775 (0 days old master)
|__/                   |  x86_64-pc-linux-gnu

julia> Pkg.test("MacroTools")
INFO: Testing MacroTools
...

WARNING: deprecated syntax "parametric method syntax foo{}(x,; )::Any around /home/justin/.julia/v0.7/MacroTools/src/utils.jl:245".
Use "foo(x,; ) where {}" instead.

WARNING: deprecated syntax "parametric method syntax add{}(a, b = 2; c = 3, d = 4)::Float64 around /home/justin/.julia/v0.7/MacroTools/src/utils.jl:245".
Use "add(a, b = 2; c = 3, d = 4) where {}" instead.

WARNING: deprecated syntax "parametric method syntax fparam{T}(a::T,; )::Any around /home/justin/.julia/v0.7/MacroTools/src/utils.jl:245".
Use "fparam(a::T,; ) where T" instead.

WARNING: deprecated syntax "parametric method syntax ::Orange{}(x,; )::Any around /home/justin/.julia/v0.7/MacroTools/src/utils.jl:245".
Use "false(x,; ) where {}" instead.

WARNING: deprecated syntax "parametric method syntax fwhere{T}(a::T,; )::Any around /home/justin/.julia/v0.7/MacroTools/src/utils.jl:245".
Use "fwhere(a::T,; ) where T" instead.
INFO: MacroTools tests passed
```