### PR TITLE
Missing backticks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ end
 function name{params}(args; kwargs)::rtype where {whereparams}
    body
 end
+```
 
 and returns `Dict(:name=>..., :args=>..., etc.)`. The definition can be rebuilt by
 calling `MacroTools.combinedef(dict)`, or explicitly with


### PR DESCRIPTION
Some backticks for a code block were missed and they made the text near the end of the README look a little strange.