### PR TITLE
Improve gatherwheres function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -191,6 +191,9 @@ function gatherwheres(ex)
   if @capture(ex, (f_ where {params1__}))
     f2, params2 = gatherwheres(f)
     (f2, (params1..., params2...))
+  elseif @capture(ex, (f_::rtype_ where {params1__}))
+      f2, params2 = gatherwheres(:($f::$rtype))
+      (f2, (params1..., params2...))
   else
     (ex, ())
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,8 @@ let
     @test fwhere(10) == Int
     @splitcombine manywhere(x::T, y::Vector{U}) where T <: U where U = (T, U)
     @test manywhere(1, Number[2.0]) == (Int, Number)
+    @splitcombine addwhere(a::T, b::S)::T where T where S = T(a+b)
+    @test addwhere(1,2.0) == 3
 
     struct Foo{A, B}
         a::A


### PR DESCRIPTION
I noticed that the function `gatherwheres` was not doing the right thing when the method had return type annotation and multiple type parameters specified with `where` clauses. So I added a special case to `gatherwheres` to handle this situation. I added a new test to cover this.