### PR TITLE
fix (nearly all) deprecations on v0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.30.0
+Compat 0.54

--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -16,7 +16,9 @@ include("examples/destruct.jl")
 include("examples/threading.jl")
 include("examples/forward.jl")
 
-animals_file = joinpath(dirname(@__FILE__), "..", "animals.txt")
-const animals = shuffle(Symbol.(lowercase.(split(read(animals_file, String)))))
+function __init__()
+    animals_file = joinpath(dirname(@__FILE__), "..", "animals.txt")
+    global animals = shuffle(Symbol.(lowercase.(split(read(animals_file, String)))))
+end
 
 end # module

--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -17,8 +17,8 @@ include("examples/threading.jl")
 include("examples/forward.jl")
 
 function __init__()
-    animals_file = joinpath(dirname(@__FILE__), "..", "animals.txt")
-    global animals = shuffle(Symbol.(lowercase.(split(read(animals_file, String)))))
+  animals_file = joinpath(dirname(@__FILE__), "..", "animals.txt")
+  global animals = shuffle(Symbol.(lowercase.(split(read(animals_file, String)))))
 end
 
 end # module

--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -2,6 +2,8 @@ __precompile__(true)
 module MacroTools
 
 using Compat
+using Compat.Markdown
+using Compat.Random
 export @match, @capture
 
 include("match.jl")
@@ -14,10 +16,7 @@ include("examples/destruct.jl")
 include("examples/threading.jl")
 include("examples/forward.jl")
 
-function __init__()
-  animals_file = joinpath(dirname(@__FILE__), "..", "animals.txt")
-  global const animals =
-    shuffle(Symbol.(lowercase.(split(read(animals_file, String)))))
-end
+animals_file = joinpath(dirname(@__FILE__), "..", "animals.txt")
+const animals = shuffle(Symbol.(lowercase.(split(read(animals_file, String)))))
 
 end # module

--- a/src/examples/destruct.jl
+++ b/src/examples/destruct.jl
@@ -6,12 +6,12 @@ isatom(x) = symbolliteral(x) || typeof(x) ∉ (Symbol, Expr)
 
 atoms(f, ex) = MacroTools.postwalk(x -> isatom(x) ? f(x) : x, ex)
 
-get′(d::Associative, k::Symbol) =
+get′(d::AbstractDict, k::Symbol) =
   haskey(d, k) ? d[k] :
   haskey(d, string(k)) ? d[string(k)] :
   error("Couldn't destruct key `$k` from collection $d")
 
-get′(d::Associative, k::Symbol, default) =
+get′(d::AbstractDict, k::Symbol, default) =
   haskey(d, k) ? d[k] :
   haskey(d, string(k)) ? d[string(k)] :
   default

--- a/src/match.jl
+++ b/src/match.jl
@@ -11,7 +11,7 @@ function store!(env, name, ex)
 end
 
 isbinding(s) = false
-isbinding(s::Symbol) = Base.ismatch(r"[^_]_(_str)?$", string(s))
+isbinding(s::Symbol) = contains(string(s), r"[^_]_(_str)?$")
 
 function bname(s::Symbol)
   Symbol(Base.match(r"^@?(.*?)_+(_str)?$", string(s)).captures[1])
@@ -26,7 +26,7 @@ match_inner(pat::QuoteNode, ex::QuoteNode, env) =
   match(pat.value, ex.value, env)
 
 isslurp(s) = false
-isslurp(s::Symbol) = s == :__ || Base.ismatch(r"[^_]__$", string(s))
+isslurp(s::Symbol) = s == :__ || contains(string(s), r"[^_]__$")
 
 function slurprange(pat)
   slurps = length(filter(isslurp, pat))

--- a/src/types.jl
+++ b/src/types.jl
@@ -14,7 +14,7 @@ totype(s::Symbol) = string(s)[1] in 'A':'Z' ? s : Expr(:quote, s)
 function tbnew(s::Symbol)
   istb(s) || return s
   ts = map(Symbol, split(string(s), "_"))
-  name = shift!(ts)
+  name = popfirst!(ts)
   ts = map(totype, ts)
   Expr(:$, :(MacroTools.TypeBind($(Expr(:quote, name)), Set{Any}([$(ts...)]))))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -137,19 +137,21 @@ function alias_gensyms(ex)
   end
 end
 
-# Helper function, from Compat. Use Base.macroexpand in 0.7
-macroexpandmodule(mod::Module, @nospecialize(x)) = eval(mod, :(macroexpand($(QuoteNode(x)))))
-
 """
 More convenient macro expansion, e.g.
 
     @expand @time foo()
 """
-macro expand(ex)
-  :(alias_gensyms(macroexpandmodule($(@static isdefined(Base, Symbol("@__MODULE__")) ?
-                                      __module__ : current_module()),
-                                    $(ex,)[1])))
+@static if VERSION <= v"0.7.0-DEV.484"
+  macro expand(ex)
+    :(alias_gensyms(macroexpand($(current_module()), $(ex,)[1])))
+  end
+else
+  macro expand(ex)
+    :(alias_gensyms(macroexpand($(__module__), $(ex,)[1])))
+  end
 end
+
 
 "Test for function definition expressions."
 isdef(ex) = ismatch(or_(:(function _(__) _ end),
@@ -196,7 +198,7 @@ function gatherwheres(ex)
   end
 end
 
-doc"""    splitdef(fdef)
+md"""    splitdef(fdef)
 
 Match any function definition
 

--- a/test/destruct.jl
+++ b/test/destruct.jl
@@ -12,7 +12,7 @@ import Base: ==
 
 struct S
     data::Vector{UInt8}
-    S(s) = new(Vector{UInt8}(s))
+    S(s) = new(codeunits(s))
 end
 ==(s1::S, s2::S) = s1.data == s2.data
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,10 @@ let
   @capture(ex, type T_ fields__ end)
   @test T == :Foo
   @test fields == [:(x::Int), :y]
+  
+  @capture(ex, mutable struct T_ fields__ end)
+  @test T == :Foo
+  @test fields == [:(x::Int), :y]
 end
 
 let

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using MacroTools
-using Base.Test
+using Compat
+using Compat.Test
 
 let
   x = @match :(2+3) begin


### PR DESCRIPTION
The only remaining deprecation is that one of the tests tries to do:

```
@capture(ex, type T_ fields__ end)
```

which throws a deprecation warning for the old syntax. It should be safe to just delete that test when dropping v0.6 support eventually. 