### PR TITLE
Expand support of splitarg to function calls.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -304,8 +304,8 @@ function splitarg(arg_expr)
     splitvar(arg) =
         @match arg begin
             ::T_ => (nothing, T)
-            name_::T_ => (name::Symbol, T)
-            x_ => (x::Symbol, :Any)
+            name_::T_ => (name, T)
+            x_ => (x, :Any)
         end
     (is_splat = @capture(arg_expr, arg_expr2_...)) || (arg_expr2 = arg_expr)
     if @capture(arg_expr2, arg_ = default_)


### PR DESCRIPTION
If we are splitting args in a function call, we cannot assume that these fields are `Symbol`s. They might be `Expr`s.