### PR TITLE
Don't drop required macro arguments in longdef1

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,7 +52,15 @@ Remove the line nodes from a block or array of expressions.
 Compare `quote end` vs `rmlines(quote end)`
 """
 rmlines(x) = x
-rmlines(x::Expr) = Expr(x.head, filter(x->!isline(x), x.args)...)
+function rmlines(x::Expr)
+  # Do not strip the first argument to a macrocall, which is
+  # required.
+  if x.head == :macrocall && length(x.args) >= 2
+    Expr(x.head, x.args[1:2]..., filter(x->!isline(x), x.args[3:end])...)
+  else
+    Expr(x.head, filter(x->!isline(x), x.args)...)
+  end
+end
 
 striplines(ex) = prewalk(rmlines, ex)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,15 @@ macro splitcombine(fundef) # should be a no-op
     esc(MacroTools.combinedef(dict))
 end
 
+# Macros for testing that splitcombine doesn't break
+# macrocalls in bodies
+macro zeroarg()
+   :(1)
+end
+macro onearg(x)
+   :(1+$(esc(x)))
+end
+
 let
     # Ideally we'd compare the result against :(function f(x)::Int 10 end),
     # but it fails because of :line and :block differences
@@ -120,6 +129,10 @@ let
     @test fwhere(10) == Int
     @splitcombine manywhere(x::T, y::Vector{U}) where T <: U where U = (T, U)
     @test manywhere(1, Number[2.0]) == (Int, Number)
+    @splitcombine fmacro0() = @zeroarg
+    @test fmacro0() == 1
+    @splitcombine fmacro1() = @onearg 1
+    @test fmacro1() == 2
 
     struct Foo{A, B}
         a::A


### PR DESCRIPTION
The LineNumberNode that's the first argument to a macrocall Expr is
required and dropping it causes bad errors such the one in
https://github.com/JuliaPy/PyCall.jl/issues/479