### PR TITLE
Option to deterministically generate unique ids instead of randomized animal names

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,26 +131,26 @@ end
 isgensym(s::Symbol) = contains(string(s), "#")
 isgensym(s) = false
 
+function gensymname(x::Symbol)
+  m = Base.match(r"##(.+)#\d+", String(x))
+  m == nothing || return m.captures[1]
+  m = Base.match(r"#\d+#(.+)", String(x))
+  m == nothing || return m.captures[1]
+  return "x"
+end
+
 """
-    gensyms_to_ids(expr)
+    gensym_ids(expr)
 
 Replaces gensyms with unique ids (deterministically)
 """
-function gensyms_to_ids(ex)
+function gensym_ids(ex)
   counter = 0
-  base_id = "sym_id_"
   syms = Dict{Symbol, Symbol}()
   prewalk(ex) do x
-    if isgensym(x)
-      repl_sym = Symbol("$base_id$counter")
-      #tried the following, but it did not work:
-      #repl_sym = Symbol(replace(string(x), "#", ""))
-      counter+=1
-      Base.@get!(syms, x, repl_sym)
-    else
+    isgensym(x) ?
+      Base.@get!(syms, x, Symbol(gensymname(x), "_", counter+=1)) :
       x
-    end
-
   end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -132,10 +132,33 @@ isgensym(s::Symbol) = contains(string(s), "#")
 isgensym(s) = false
 
 """
+    gensyms_to_ids(expr)
+
+Replaces gensyms with unique ids (deterministically)
+"""
+function gensyms_to_ids(ex)
+  counter = 0
+  base_id = "sym_id_"
+  syms = Dict{Symbol, Symbol}()
+  prewalk(ex) do x
+    if isgensym(x)
+      repl_sym = Symbol("$base_id$counter")
+      #tried the following, but it did not work:
+      #repl_sym = Symbol(replace(string(x), "#", ""))
+      counter+=1
+      Base.@get!(syms, x, repl_sym)
+    else
+      x
+    end
+
+  end
+end
+
+"""
     alias_gensyms(expr)
 
-Replaces gensyms with animal names. This makes gensym'd code far easier to
-follow.
+Replaces gensyms with animal names
+This makes gensym'd code far easier to follow.
 """
 function alias_gensyms(ex)
   left = copy(animals)


### PR DESCRIPTION
There are a couple of problems with the current animal name scheme used in alias_gensyms:

1) There are only about 220 animal names in animals.txt. If you have more than 220 gensyms the following line in the current _alias_gensyms_ function is going to error out:

`Base.@get!(syms, x, pop!(left))`

(_left_ is a copy of the animals symbol list)

2) Currently, the animal names list is randomized when the package is initialized.  While working on ONNX.jl we were finding that given the same inputs we would get different code generated due to this randomization. This makes it very difficult for us to debug as we made changes to ONNX.jl and wanted to compare code generated from a prior version on the same inputs.

This patch generates a simple unique id in the form of "sym_id_$counter" where the counter value is incremented on each gensym encountered.

I would have preferred replacing all of the "#" characters in the gensym with blanks, however that did not work for me even though I tried the same scheme in the REPL on a gensym string and it did work (see the comment I added in _alias_gensyms_  - maybe someone could get that working?)

