### PR TITLE
splitstructdef

### DIFF
--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -10,6 +10,7 @@ include("types.jl")
 include("union.jl")
 include("macro.jl")
 include("utils.jl")
+include("structdef.jl")
 
 include("examples/destruct.jl")
 include("examples/threading.jl")

--- a/src/structdef.jl
+++ b/src/structdef.jl
@@ -1,0 +1,67 @@
+const STRUCTSYMBOL = VERSION < v"0.7-" ? :type : :struct
+isstructdef(ex) = Meta.isexpr(ex, STRUCTSYMBOL)
+
+function splitstructdef(ex)
+    ex = MacroTools.striplines(ex)
+    ex = MacroTools.flatten(ex)
+    d = Dict{Symbol, Any}()
+    if @capture(ex, struct header_ body__ end)
+        d[:mutable] = false
+    elseif @capture(ex, mutable struct header_ body__ end)
+        d[:mutable] = true
+    else
+        parse_error(ex)
+    end
+    
+    if @capture header nameparam_ <: super_
+        nothing
+    elseif @capture header nameparam_
+        super = :Any
+    else
+        parse_error(ex)
+    end
+    d[:supertype] = super
+    if @capture nameparam name_{param__}
+        nothing
+    elseif @capture nameparam name_
+        param = []
+    else
+        parse_error(ex)
+    end
+    d[:name] = name
+    d[:params] = param
+    d[:fields] = []
+    d[:constructors] = []
+    for item in body
+        if @capture item field_::T_
+            push!(d[:fields], (field, T))
+        elseif item isa Symbol
+            push!(d[:fields], (item, Any))
+        else
+            push!(d[:constructors], item)
+        end
+    end
+    d
+end
+
+function combinestructdef(d)::Expr
+    name = d[:name]
+    parameters = d[:params]
+    nameparam = isempty(parameters) ? name : :($name{$(parameters...)})
+    header = :($nameparam <: $(d[:supertype]))
+    fields = map(d[:fields]) do field
+        fieldname, typ = field
+        :($fieldname::$typ)
+    end
+    body = quote
+        $(fields...)
+        $(d[:constructors]...)
+    end
+
+    Expr(STRUCTSYMBOL, d[:mutable], header, body)
+end
+
+function combinefield(x)
+    fieldname, T = x
+    :($fieldname::$T)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,3 +150,4 @@ let
 end
 
 include("destruct.jl")
+include("structdef.jl")

--- a/test/structdef.jl
+++ b/test/structdef.jl
@@ -1,0 +1,45 @@
+using MacroTools: splitstructdef, combinestructdef
+
+@testset "combinestructdef, splitstructdef" begin
+    ex = :(struct S end)
+    @test ex |> splitstructdef |> combinestructdef |> Base.remove_linenums! == 
+        :(struct S <: Any end)
+    
+    @test splitstructdef(ex) == Dict(
+        :constructors => Any[],
+        :mutable => false,
+        :params => Any[],
+        :name => :S,
+        :fields => Any[],
+        :supertype => :Any)
+
+    ex = :(mutable struct T end)
+    @test splitstructdef(ex)[:mutable] === true
+    @test ex |> splitstructdef |> combinestructdef |> Base.remove_linenums! == 
+        :(mutable struct T <: Any end)
+
+    ex = :(struct S{A,B} <: AbstractS{B}
+                               a::A
+                           end)
+    @test splitstructdef(ex) == Dict(
+        :constructors => Any[],
+        :mutable => false,
+        :params => Any[:A, :B],
+        :name => :S,
+        :fields => Any[(:a, :A)],
+        :supertype => :(AbstractS{B}),)
+
+    @test ex |> splitstructdef |> combinestructdef |> Base.remove_linenums! == 
+        ex |> Base.remove_linenums!
+
+    ex = :(struct S{A} <: Foo; S(a::A) where {A} = new{A}() end)
+    @test ex |> splitstructdef |> combinestructdef |>
+        Base.remove_linenums! |> MacroTools.flatten ==
+        ex |> Base.remove_linenums! |> MacroTools.flatten
+
+    constructors = splitstructdef(ex)[:constructors]
+    @test length(constructors) == 1
+    @test first(constructors) ==
+        :((S(a::A) where A) = new{A}()) |> MacroTools.flatten
+
+end


### PR DESCRIPTION
This is copy pasted from [Setfield.jl](https://github.com/jw3126/Setfield.jl/blob/master/src/macrotools.jl), I think MacroTools would be a better home for it. It is like splitdef, but targets struct definitions instead of method definitions.