### PR TITLE
Move initializing `animals` out of __init__ to global scope.

### DIFF
--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -19,11 +19,10 @@ include("examples/forward.jl")
 const animals = Symbol[]
 const animals_file = joinpath(dirname(@__FILE__), "..", "animals.txt")
 
-function __init__()
-  _animals = split(read(animals_file, String))
-  resize!(animals, length(_animals))
-  animals .= Symbol.(lowercase.(_animals))
-  Compat.Random.shuffle!(animals)
-end
+# Load and initialize animals symbols.
+_animals = split(read(animals_file, String))
+resize!(animals, length(_animals))
+animals .= Symbol.(lowercase.(_animals))
+Compat.Random.shuffle!(animals)
 
 end # module


### PR DESCRIPTION
Before, having `__init__` read from the filesystem was causing problems with
static compiling.

So I've just moved the initialization out of the `__init__` function, and deleted the now-empty function entirely.

Per the julia docs, intializing an array like this doesn't need to be in
`__init__` anway, the whole array can be serialized during precompilation.

Here's the relevant section (from [Module-initialization-and-precompilation](https://docs.julialang.org/en/v0.6.4/manual/modules/#Module-initialization-and-precompilation-1)):

> Constants involving most Julia objects that are not produced by ccall
> do not need to be placed in __init__: their definitions can be
> precompiled and loaded from the cached module image. This includes
> complicated heap-allocated objects like arrays. However, any routine
> that returns a raw pointer value must be called at runtime for
> precompilation to work (Ptr objects will turn into null pointers
> unless they are hidden inside an isbits object). This includes the
> return values of the Julia functions cfunction and pointer.