### PR TITLE
.' operator is gone in Julia 1.0

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -388,7 +388,6 @@ function resyntax(ex)
       getindex(x_, i__) => :($x[$(i...)])
       tuple(xs__) => :($(xs...),)
       ctranspose(x_) => :($x')
-      transpose(x_) => :($x.')
       _ => x
     end
   end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -387,7 +387,7 @@ function resyntax(ex)
       setfield!(x_, :f_, v_) => :($x.$f = $v)
       getindex(x_, i__) => :($x[$(i...)])
       tuple(xs__) => :($(xs...),)
-      ctranspose(x_) => :($x')
+      adjoint(x_) => :($x')
       _ => x
     end
   end


### PR DESCRIPTION
julia> [1 2].'
ERROR: syntax: the ".'" operator is discontinued