### PR TITLE
Added backward compatibility with Julia 0.6

### DIFF
--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -1,3 +1,4 @@
+VERSION < v"0.7.0-beta2.199" && __precompile__(true)
 module MacroTools
 
 using Compat


### PR DESCRIPTION
There were some related discussions here: https://github.com/MikeInnes/MacroTools.jl/commit/18448ba5e26624345f6f4eef9f05e4aa09b03387#r30081444

This one-liner fixes backward compatibility with 0.6. All the 0.6 packages that depend on MacroTools and are marked as `__precompile__(true)` won't work without this.