### PR TITLE
Have @forward handle kwargs

### DIFF
--- a/src/examples/forward.jl
+++ b/src/examples/forward.jl
@@ -14,7 +14,8 @@ macro forward(ex, fs)
   @capture(ex, T_.field_) || error("Syntax: @forward T.x f, g, h")
   T = esc(T)
   fs = isexpr(fs, :tuple) ? map(esc, fs.args) : [esc(fs)]
-  :($([:($f(x::$T, args...) = (Base.@_inline_meta; $f(x.$field, args...)))
+  :($([:($f(x::$T, args...; kwargs...) =
+         (Base.@_inline_meta; $f(x.$field, args...; kwargs...)))
        for f in fs]...);
     nothing)
 end


### PR DESCRIPTION
Now that kwargs are fast on Julia 1.0, this seems reasonable.