### PR TITLE
Fix `inexpr()` failing to find things due to its return value

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -128,7 +128,10 @@ inside `expr`.
 function inexpr(ex, x)
   result = false
   MacroTools.postwalk(ex) do y
-    y == x && (result = true)
+    if y == x 
+      result = true
+    end
+    return y
   end
   return result
 end


### PR DESCRIPTION
Without this change, `inexpr()` would fail to find things because it would return values that then replaced elements of the AST it was walking through.