### PR TITLE
more faithfully reconstruct original function in combinedef

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -288,6 +288,7 @@ function combinedef(dict::Dict)
   rtype = get(dict, :rtype, nothing)
   params = get(dict, :params, [])
   wparams = get(dict, :whereparams, [])
+  body = block(dict[:body])
   name = dict[:name]
   name_param = isempty(params) ? name : :($name{$(params...)})
   # We need the `if` to handle parametric inner/outer constructors like
@@ -296,24 +297,24 @@ function combinedef(dict::Dict)
     if rtype==nothing
       @q(function $name_param($(dict[:args]...);
                               $(dict[:kwargs]...))
-        $(dict[:body].args...)
+        $(body.args...)
         end)
     else
       @q(function $name_param($(dict[:args]...);
                               $(dict[:kwargs]...))::$rtype
-        $(dict[:body].args...)
+        $(body.args...)
         end)
     end
   else
     if rtype==nothing
       @q(function $name_param($(dict[:args]...);
                               $(dict[:kwargs]...)) where {$(wparams...)}
-        $(dict[:body].args...)
+        $(body.args...)
         end)
     else
       @q(function $name_param($(dict[:args]...);
                               $(dict[:kwargs]...))::$rtype where {$(wparams...)}
-        $(dict[:body].args...)
+        $(body.args...)
         end)
     end
   end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -201,7 +201,7 @@ isshortdef(ex) = (@capture(ex, (fcall_ = body_)) &&
 
 function longdef1(ex)
   if @capture(ex, (arg_ -> body_))
-    @q function ($arg,) $body end
+    @q function ($arg,) $(body.args...) end
   elseif isshortdef(ex)
     @assert @capture(ex, (fcall_ = body_))
     striplines(Expr(:function, fcall, body))
@@ -213,12 +213,13 @@ longdef(ex) = prewalk(longdef1, ex)
 
 function shortdef1(ex)
   @match ex begin
-    function f_(args__) body_ end => @q $f($(args...)) = $body
-    function f_(args__) where T__ body_ end => @q $f($(args...)) where $(T...) = $body
-    function f_(args__)::rtype_ body_ end => @q $f($(args...))::$rtype = $body
-    function (args__,) body_ end => @q ($(args...),) -> $body
+    function f_(args__) body_ end => @q $f($(args...)) = $(body.args...)
+    function f_(args__) where T__ body_ end => @q $f($(args...)) where $(T...) = $(body.args...)
+    function f_(args__)::rtype_ body_ end => @q $f($(args...))::$rtype = $(body.args...)
+    function f_(args__)::rtype_ where T__ body_ end => @q ($f($(args...))::$rtype) where $(T...) = $(body.args...)
+    function (args__,) body_ end => @q ($(args...),) -> $(body.args...)
     ((args__,) -> body_) => ex
-    (arg_ -> body_) => @q ($arg,) -> $body
+    (arg_ -> body_) => @q ($arg,) -> $(body.args...)
     _ => ex
   end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -307,12 +307,12 @@ function combinedef(dict::Dict)
     if rtype==nothing
       @q(function $name_param($(dict[:args]...);
                               $(dict[:kwargs]...)) where {$(wparams...)}
-        $(dict[:body]...)
+        $(dict[:body].args...)
         end)
     else
       @q(function $name_param($(dict[:args]...);
                               $(dict[:kwargs]...))::$rtype where {$(wparams...)}
-        $(dict[:body]...)
+        $(dict[:body].args...)
         end)
     end
   end


### PR DESCRIPTION
Previously `combinedef` would put an `::Any` return type annotation on any function it reconstructed that didn't have one originally, and also wrap the function body in one extra `begin` block. These both seem completely superfluous except amazingly when combined they trigger the bug I reported here: https://github.com/JuliaLang/julia/issues/29326. 

This PR gets rid of those things and more faithfully reconstructs the original function. 

I also switched to returning the expression via `@q` which would allow whatever macro is calling `combinedef` to insert the desired line numbers in there. 