### PR TITLE
Don't strip lines in longdef1

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -209,7 +209,7 @@ function longdef1(ex)
     @q function ($arg,) $(body.args...) end
   elseif isshortdef(ex)
     @assert @capture(ex, (fcall_ = body_))
-    striplines(Expr(:function, fcall, body))
+    Expr(:function, fcall, body)
   else
     ex
   end


### PR DESCRIPTION
Fix #102 

All tests pass but.... why did you have striplines there in the first place? Did it handle a special case?