### PR TITLE
Avoid hard coding the animal path when compiling the package

### DIFF
--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -17,12 +17,15 @@ include("examples/threading.jl")
 include("examples/forward.jl")
 
 const animals = Symbol[]
-const animals_file = joinpath(@__DIR__, "..", "animals.txt")
 
-# Load and initialize animals symbols.
-_animals = split(read(animals_file, String))
-resize!(animals, length(_animals))
-animals .= Symbol.(lowercase.(_animals))
-Compat.Random.shuffle!(animals)
+function __init__()
+    animals_file = joinpath(@__DIR__, "..", "animals.txt")
+
+    # Load and initialize animals symbols.
+    _animals = split(read(animals_file, String))
+    resize!(animals, length(_animals))
+    animals .= Symbol.(lowercase.(_animals))
+    Compat.Random.shuffle!(animals)
+end
 
 end # module


### PR DESCRIPTION
This is a problem when trying to use PackageCompiler with this package.