### PR TITLE
Fix linenumbers when using @q with macro calls

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,10 +60,9 @@ Compare `quote end` vs `rmlines(quote end)`
 """
 rmlines(x) = x
 function rmlines(x::Expr)
-  # Do not strip the first argument to a macrocall, which is
-  # required.
+  # :macrocall has a LineNumberNode as second argument, which we replace by `nothing`
   if x.head == :macrocall && length(x.args) >= 2
-    Expr(x.head, x.args[1:2]..., filter(x->!isline(x), x.args[3:end])...)
+    Expr(x.head, x.args[1], nothing, filter(x->!isline(x), x.args[3:end])...)
   else
     Expr(x.head, filter(x->!isline(x), x.args)...)
   end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,7 +61,7 @@ Compare `quote end` vs `rmlines(quote end)`
 rmlines(x) = x
 function rmlines(x::Expr)
   # :macrocall has a LineNumberNode as second argument, which we replace by `nothing`
-  if x.head == :macrocall && length(x.args) >= 2
+  if x.head == :macrocall && length(x.args) >= 2 && VERSION >= v"0.7"
     Expr(x.head, x.args[1], nothing, filter(x->!isline(x), x.args[3:end])...)
   else
     Expr(x.head, filter(x->!isline(x), x.args)...)

--- a/test/match.jl
+++ b/test/match.jl
@@ -1,4 +1,4 @@
-@test postwalk(@q (@time 2+2)) do x  # issue #107
+@test MacroTools.postwalk(MacroTools.@q (@time 2+2)) do x  # issue #107
   @assert !MacroTools.isline(x)
   true
 end

--- a/test/match.jl
+++ b/test/match.jl
@@ -1,3 +1,9 @@
+@test postwalk(@q (@time 2+2)) do x  # issue #107
+  @assert !MacroTools.isline(x)
+  true
+end
+
+
 let
   x = @match :(2+3) begin
     (a_+b_) => (a, b)


### PR DESCRIPTION
Fix #107 by replacing the `:macrocall` line-number argument with `nothing`. I haven't read anywhere that this is Acceptable, but it seems to work.