### PR TITLE
updatedocs

### DIFF
--- a/docs/src/pattern-matching.md
+++ b/docs/src/pattern-matching.md
@@ -48,7 +48,7 @@ Because `@capture` doubles as a test as well as extracting values, you can
 easily handle unexpected input (try writing this by hand):
 
 ```julia
-@capture(ex, f_{T_}(xs__) = body_) ||
+@capture(ex, f_(xs__) where {T_} = body_) ||
   error("expected a function with a single type parameter")
 ```
 
@@ -105,10 +105,10 @@ will match both kinds of function syntax (though it's easier to use
 expressions, e.g.
 
 ```julia
-@capture(ex, (f_{T_}|f_)(args__) = body_)
+@capture(ex, (f_(args__) where {T_}) | (f_(args__)) = body_)
 ```
 
-matches a function definition, with a single type parameter bound to `T` if possible.
+matches a function definition like `func(a::T) where {T<:Number} = supertype(T)`, with a single type parameter bound to `T` if possible.
 If not, `T = nothing`.
 
 ## Expression Walking

--- a/docs/src/pattern-matching.md
+++ b/docs/src/pattern-matching.md
@@ -97,7 +97,7 @@ which will match e.g. `struct Foo ...` but not `struct Foo{V} ...`
 for example:
 
 ```julia
-@capture(ex, f_(args__) = body_ | function f_(args__) body_ end)
+@capture(ex, (f_(args__) = body_) | (function f_(args__) body_ end))
 ```
 
 will match both kinds of function syntax (though it's easier to use

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -44,32 +44,18 @@ and returns `Dict(:name=>..., :args=>..., etc.)`. The definition can be rebuilt 
 calling `MacroTools.combinedef(dict)`, or explicitly with
 
 ```julia
-rtype = get(dict, :rtype, nothing)
+rtype = get(dict, :rtype, :Any)
 wparams = get(dict, :whereparams, [])
 if isempty(wparams)
-  if rtype==nothing
-    :(function $(dict[:name])($(dict[:args]...);
-                              $(dict[:kwargs]...))
-      $(body.args...)
-    end)
-  else
-    :(function $(dict[:name])($(dict[:args]...);
-                              $(dict[:kwargs]...))::$rtype
-      $(body.args...)
-    end)
-  end
+  :(function $(dict[:name])($(dict[:args]...);
+                            $(dict[:kwargs]...))::$rtype
+    $(body.args...)
+  end)
 else
-  if rtype==nothing
-    :(function $(dict[:name])($(dict[:args]...);
-                               $(dict[:kwargs]...)) where {$(wparams...)}
-      $(body.args...)
-    end)
-  else
-    :(function $(dict[:name])($(dict[:args]...);
-                              $(dict[:kwargs]...))::$rtype where {$(wparams...)}
-      $(body.args...)
-    end)
-  end
+  :(function $(dict[:name])($(dict[:args]...);
+                            $(dict[:kwargs]...))::$rtype where {$(wparams...)}
+    $(body.args...)
+  end)
 end
 ```
 

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -45,18 +45,10 @@ calling `MacroTools.combinedef(dict)`, or explicitly with
 
 ```julia
 rtype = get(dict, :rtype, :Any)
-wparams = get(dict, :whereparams, [])
-if isempty(wparams)
-  :(function $(dict[:name])($(dict[:args]...);
-                            $(dict[:kwargs]...))::$rtype
-    $(body.args...)
-  end)
-else
-  :(function $(dict[:name])($(dict[:args]...);
-                            $(dict[:kwargs]...))::$rtype where {$(wparams...)}
-    $(body.args...)
-  end)
-end
+:(function $(dict[:name])($(dict[:args]...);
+                          $(dict[:kwargs]...))::$rtype where {$(dict[:whereparams]...)}
+  $(dict[:body].args...)
+end)
 ```
 
 `splitarg(arg)` matches function arguments (whether from a definition or a function call)


### PR DESCRIPTION
Let's updates docs :)

- fix the not-working example of union expression matching
- update examples with static parameters and fully use the `where` syntax.