### PR TITLE
shuffle animals in init

### DIFF
--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -32,6 +32,9 @@ const animals_file = joinpath(@__DIR__, "..", "animals.txt")
 _animals = split(read(animals_file, String))
 resize!(animals, length(_animals))
 animals .= Symbol.(lowercase.(_animals))
-Compat.Random.shuffle!(animals)
+
+function __init__()
+    Compat.Random.shuffle!(animals)
+end
 
 end # module


### PR DESCRIPTION
Makes it easier to include this package in a sysimage since the default rng is not usable when outputting to a file.

Of course, it is possible to just call `Random.__init__()`  but it is in general best imo to try make the precompilation file as deterministic as possible.

Alternatively, the `animals.txt` file can just be line shuffled.