### PR TITLE
move shuffling of animals to be done on demand instead of during initialization

### DIFF
--- a/src/MacroTools.jl
+++ b/src/MacroTools.jl
@@ -22,6 +22,6 @@ const animals_file = joinpath(@__DIR__, "..", "animals.txt")
 _animals = split(read(animals_file, String))
 resize!(animals, length(_animals))
 animals .= Symbol.(lowercase.(_animals))
-
+Random.shuffle!(animals)
 
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -190,9 +190,6 @@ function gensym_ids(ex)
   end
 end
 
-const l = ReentrantLock()
-const shuffled = Ref{Bool}(false)
-
 """
     alias_gensyms(expr)
 
@@ -208,12 +205,6 @@ julia> MacroTools.alias_gensyms(:(\$x+\$y))
 ```
 """
 function alias_gensyms(ex)
-  lock(l) do
-    if !shuffled[]
-      Random.shuffle!(animals)
-      shuffled[] = true
-    end
-  end
   left = copy(animals)
   syms = Dict{Symbol, Symbol}()
   prewalk(ex) do x


### PR DESCRIPTION
This package is heavily used throughout the ecosystem so optimizing its load time is quite important. The compilation time of the `shuffle!` call in the `__init__` function adds quite a bit of overhead, so I moved this to be done the first time the variable is actually used instead.

Without this PR:

```
julia> @time using MacroTools
  0.067275 seconds (142.56 k allocations: 9.640 MiB, 61.33% compilation time)
```

With this PR:

```
julia> @time using MacroTools
  0.024947 seconds (28.79 k allocations: 3.159 MiB, 22.04% compilation time)
```

It also removed quite a bit of "noise" when profiling other packages load time that happens to depend on this pacakge recursively. 