### PR TITLE
Fixes 165, Fixes 177.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -408,7 +408,7 @@ end
 function combinearg(arg_name, arg_type, is_splat, default)
     @assert arg_name !== nothing || arg_type !== nothing
     a = arg_name===nothing ? :(::$arg_type) :
-        arg_type===nothing ? arg_name :
+        arg_type==:Any ? arg_name :
             :($arg_name::$arg_type)
     a2 = is_splat ? Expr(:..., a) : a
     return default === nothing ? a2 : Expr(:kw, a2, default)
@@ -418,16 +418,16 @@ end
     splitarg(arg)
 
 Match function arguments (whether from a definition or a function call) such as
-`x::Int=2` and return `(arg_name, arg_type, is_splat, default)`. `arg_name`,
-`arg_type`, and `default` are `nothing` when they are absent. For example:
+`x::Int=2` and return `(arg_name, arg_type, is_splat, default)`. `arg_name` and
+`default` are `nothing` when they are absent. For example:
 
 ```julia
 julia> map(splitarg, (:(f(a=2, x::Int=nothing, y, args...))).args[2:end])
 4-element Array{Tuple{Symbol,Symbol,Bool,Any},1}:
- (:a, nothing, false, 2)
+ (:a, :Any, false, 2)
  (:x, :Int, false, :nothing)
  (:y, :Any, false, nothing)
- (:args, nothing, true, nothing)
+ (:args, :Any, true, nothing)
 ```
 
 See also: [`combinearg`](@ref)
@@ -443,7 +443,7 @@ function splitarg(arg_expr)
     (arg_name, arg_type) = (@match arg_expr3 begin
         ::T_ => (nothing, T)
         name_::T_ => (name, T)
-        x_ => (x, nothing)
+        x_ => (x, :Any)
     end)::NTuple{2,Any} # the pattern `x_` matches any expression
     return (arg_name, arg_type, is_splat, default)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -408,7 +408,7 @@ end
 function combinearg(arg_name, arg_type, is_splat, default)
     @assert arg_name !== nothing || arg_type !== nothing
     a = arg_name===nothing ? :(::$arg_type) :
-        arg_type==:Any ? arg_name :
+        arg_type==:Any && is_splat ? arg_name :   # see #177 and julia#43625
             :($arg_name::$arg_type)
     a2 = is_splat ? Expr(:..., a) : a
     return default === nothing ? a2 : Expr(:kw, a2, default)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -434,6 +434,8 @@ See also: [`combinearg`](@ref)
 """
 function splitarg(arg_expr)
     if @capture(arg_expr, arg_expr2_ = default_)
+      # This assert will only be triggered if a `nothing` literal was somehow spliced into the Expr.
+      # A regular `nothing` default value is a `Symbol` when it gets here. See #178 
       @assert default !== nothing "splitarg cannot handle `nothing` as a default. Use a quoted `nothing` if possible. (MacroTools#35)"
     else
        arg_expr2 = arg_expr

--- a/test/split.jl
+++ b/test/split.jl
@@ -36,7 +36,7 @@ let
     args = splitdef(:(f(a::Int = 1) = 1))[:args]
     @test map(splitarg, args) == [(:a, :Int, false, 1)]
     args = splitdef(:(f(a::Int ... = 1) = 1))[:args]
-    @test map(splitarg, args) == [(:a, :Int, true, 1)]
+    @test map(splitarg, args) == [(:a, :Int, true, 1)]    # issue 165 
 
     @splitcombine foo(x) = x+2
     @test foo(10) == 12

--- a/test/split.jl
+++ b/test/split.jl
@@ -27,12 +27,12 @@ let
     @test longdef(:(f(x::T) where U where T = 2)).head == :function
     @test shortdef(:(function f(x)::Int 10 end)).head != :function
     @test map(splitarg, (:(f(a=2, x::Int=nothing, y::Any, args...))).args[2:end]) ==
-        [(:a, nothing, false, 2), (:x, :Int, false, :nothing),
-         (:y, :Any, false, nothing), (:args, nothing, true, nothing)]
+        [(:a, :Any, false, 2), (:x, :Int, false, :nothing),
+         (:y, :Any, false, nothing), (:args, :Any, true, nothing)]
     @test splitarg(:(::Int)) == (nothing, :Int, false, nothing)
     kwargs = splitdef(:(f(; a::Int = 1, b...) = 1))[:kwargs]
     @test map(splitarg, kwargs) ==
-        [(:a, :Int, false, 1), (:b, nothing, true, nothing)]
+        [(:a, :Int, false, 1), (:b, :Any, true, nothing)]
     args = splitdef(:(f(a::Int = 1) = 1))[:args]
     @test map(splitarg, args) == [(:a, :Int, false, 1)]
     args = splitdef(:(f(a::Int ... = 1) = 1))[:args]


### PR DESCRIPTION
A partial rewrite of splitarg and combinearg to fix https://github.com/FluxML/MacroTools.jl/issues/165 and https://github.com/FluxML/MacroTools.jl/issues/177.

The big change here is that `arg_type` can be `nothing` if no type is declared for an argument. I know that this is a change to the interface, but I also see no other way to fix the problem. While we are changing the interface, we may want to consider handling literal `nothing` as an argument default through the base `Some` and `something` interface. (discussed in https://github.com/FluxML/MacroTools.jl/issues/35).