### PR TITLE
Fix isdef

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MacroTools"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.11"
+version = "0.5.12"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -225,7 +225,8 @@ end
 
 
 "Test for function definition expressions."
-isdef(ex) = isshortdef(ex) || longdef1(ex) !== nothing
+isdef(ex::Expr) = isshortdef(ex) || ex.head == :function
+isdef(ex) = false
 
 isshortdef(ex) = (@capture(ex, (fcall_ = body_)) &&
                   (@capture(gatherwheres(fcall)[1],

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -224,8 +224,9 @@ macro expand(ex)
 end
 
 
-"Test for function definition expressions."
-isdef(ex::Expr) = isshortdef(ex) || ex.head == :function
+"Test for function definition expressions. `function f end` and anonymous functions are considered
+as function definitions and return true."
+isdef(ex::Expr) = isshortdef(ex) || ex.head == :function || ex.head == :->
 isdef(ex) = false
 
 isshortdef(ex) = (@capture(ex, (fcall_ = body_)) &&

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -14,7 +14,7 @@ using MacroTools: isdef, flatten, striplines
 
     ex6 = :(f(a) = a)
     @test isdef(ex6)
-    ex7 = :(f(a)::Int == 1)
+    ex7 = :(f(a)::Int = 1)
     @test isdef(ex7)
     ex8 = :(f(a::T) where T = a)
     @test isdef(ex8)
@@ -22,6 +22,10 @@ using MacroTools: isdef, flatten, striplines
     @test isdef(ex9)
     ex10 = :(f(a::S, b::T)::Union{S,T} where {S,T} = rand() < 0.5 ? a : b)
     @test isdef(ex10)
+    @test !isdef(:(f()))
+    @test !isdef(:ix)
+    @test isdef(:(function f end))  # This is an arbitrary decision (arguably can be called a
+                                    # declaration.
 end
 
 @testset "flatten" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -24,8 +24,8 @@ using MacroTools: isdef, flatten, striplines
     @test isdef(ex10)
     @test !isdef(:(f()))
     @test !isdef(:ix)
-    @test isdef(:(function f end))  # This is an arbitrary decision (arguably can be called a
-                                    # declaration.
+    @test isdef(:(function f end))  # This is an arbitrary decision. Arguably it could be called a
+                                    # function declaration, and have `isdef` return false.
     @test isdef(:(x -> x+2))
     @test isdef(:(function (y) y - 4 end))
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -26,6 +26,8 @@ using MacroTools: isdef, flatten, striplines
     @test !isdef(:ix)
     @test isdef(:(function f end))  # This is an arbitrary decision (arguably can be called a
                                     # declaration.
+    @test isdef(:(x -> x+2))
+    @test isdef(:(function (y) y - 4 end))
 end
 
 @testset "flatten" begin


### PR DESCRIPTION
This feels like the simplest fix, though I wonder why it wasn't defined like that in the first place. Hopefully from now on we can increase test coverage on each release.

Fix #172, close #173.
