### PR TITLE
Fix Julia 1.12 compatibility for MethodList API change

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -608,7 +608,11 @@ function makeif(clauses, els = nothing)
 end
 
 unresolve1(x) = x
-unresolve1(f::Function) = methods(f).mt.name
+@static if VERSION >= v"1.12-"
+    unresolve1(f::Function) = nameof(f)
+else
+    unresolve1(f::Function) = methods(f).mt.name
+end
 
 unresolve(ex) = prewalk(unresolve1, ex)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -63,6 +63,12 @@ end
     @test flatten(quote begin; begin; f(); g(); end; begin; h(); end; f(); end; end) |> striplines == quote f(); g(); h(); f() end |> striplines
 end
 
+@testset "prettify" begin
+    # Test that prettify resolves function references to their names
+    @test MacroTools.prettify(:($sin(2))) == :(sin(2))
+    @test MacroTools.prettify(:($cos(x))) == :(cos(x))
+end
+
 @testset "flatten try" begin # see julia#50710 and MacroTools#194 # only tests that do not include `else` -- for the full set of tests see flatten_try.jl
     exs = [
         quote try; f(); catch; end; end,


### PR DESCRIPTION
## Summary
- Fix `FieldError: type Base.MethodList has no field mt` on Julia 1.12
- Use version-conditional code: `nameof(f)` for Julia >= 1.12, original `methods(f).mt.name` for older versions
- The `prettify` and `unresolve` functions now work correctly on Julia 1.12

## Test plan
- [x] Verified fix works with `MacroTools.prettify(Expr(:call, +, 1, 2))` on Julia 1.12.3
- [x] All 165 existing tests pass

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)